### PR TITLE
Allow choosing the TLS framework used by sauce-api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,19 @@ version = "0.6.1-alpha3"
 
 [dependencies]
 async-trait = "0.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 select = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 strfmt = "0.1"
 thiserror = "1.0"
 urlencoding = "1.1"
+
+[features]
+default = []
+
+rustls = ["reqwest/rustls-tls"]
+
+# This does a bit more than just using default reqwest features
+# See this comment in their Cargo.toml https://github.com/seanmonstar/reqwest/blob/master/Cargo.toml#L30
+# So we don't include it in the default features, but have it for symmetry
+native_tls = ["reqwest/native-tls"]

--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ async fn find_source(url: String) {
     }
 }
 ```
+
+## Requirements
+
+sauce-api by default uses the native TLS framework, see [this](https://github.com/seanmonstar/reqwest#requirements) for specific details.
+You may opt-in to using rustls if you would like to by enabling the `rustls` feature like this:
+
+```toml
+sauce-api = { version = "0.6.0", features = ["rustls"] }
+```


### PR DESCRIPTION
This is useful when cross compiling (e.g. for a Raspberry Pi as is my
usecase 🙃)

This patch also documents the feature under a "Requirements" section in
README as the TLS stack kinda fits there.

----

This is confirmed to build as per my [CI workflow](https://github.com/RealKC/saucenao-discord-bot-rs/actions/runs/544228675) (it wouldn't build if my changes caused a problem in this crate, also the commit mentioned there is one past the commit where I switch to my fork...)