### PR TITLE
fix: Parsing IQDB correctly

### DIFF
--- a/src/source/iqdb.rs
+++ b/src/source/iqdb.rs
@@ -96,30 +96,17 @@ impl Source for Iqdb {
 
 impl Iqdb {
     fn harvest_page(page: &ElementRef) -> Option<Item> {
-        let dom = page;
-
         debug!("selecting .image a");
-        let link = dom.select(sel!(".image a")).next()?;
+        let link = page.select(sel!(".image a")).next()?;
 
         debug!("grabbing href");
         let url = link.value().attr("href")?;
 
-        debug!("collecting trs");
-        let score = dom.select(sel!("tr")).collect::<Vec<_>>();
-
-        if score.len() != 5 {
-            return Some(Item {
-                link: url.to_string(),
-                similarity: -1.0,
-            });
-        }
-
         debug!("grabbing score");
-        let score = score[3];
-        debug!("grabbing td");
-        let td = score.select(sel!("td")).next()?;
+        let score = page.select(sel!("tr:last-child > td")).next()?;
 
-        let score = td.text().collect::<String>();
+        debug!("parsing score");
+        let score = score.text().collect::<String>();
         let score = score.split_once('%')?.0.parse::<f32>().ok()? / 100.0;
 
         Some(Item {
@@ -128,34 +115,7 @@ impl Iqdb {
         })
     }
 
-    fn harvest_best_match(pages: &ElementRef) -> Option<Item> {
-        debug!("selecting .image a");
-        let link = pages.select(sel!(".image a")).next()?;
-
-        debug!("grabbing href");
-        let url = link.value().attr("href")?;
-
-        debug!("collecting trs");
-        let score = pages.select(sel!("tr")).collect::<Vec<_>>();
-
-        if score.len() != 5 {
-            return Some(Item {
-                link: url.to_string(),
-                similarity: -1.0,
-            });
-        }
-
-        debug!("grabbing score");
-        let score = score[3];
-        debug!("grabbing td");
-        let td = score.select(sel!("td")).next()?;
-
-        let score = td.text().collect::<String>();
-        let score = score.split_once('%')?.0.parse::<f32>().ok()? / 100.0;
-
-        Some(Item {
-            link: url.to_string(),
-            similarity: score,
-        })
+    fn harvest_best_match(page: &ElementRef) -> Option<Item> {
+        Self::harvest_page(page)
     }
 }


### PR DESCRIPTION
Fixes IQDB result parsing as well as simplify it. 

```toml
[package]
name = "iqdbtest"
version = "0.1.0"
edition = "2024"

[dependencies]
sauce-api = { version = "1.2.0", path = "../../github.com/lyssieth/sauce-api", features = [
  "iqdb",
  "rustls",
] }
tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }
```

```rust
use sauce_api::error::Error;
use sauce_api::source::{Output, Source, iqdb::Iqdb};

async fn find_source(url: &str) {
    let source = Iqdb::create(()).await.unwrap();
    let res: Result<Output, Error> = source.check(url).await; // Can take some time as IQDB is a bit slow.

    match res {
        Ok(result) => {
            println!("Found results! {:?}", result);
        }
        Err(e) => {
            eprintln!("Unable to find results: {}", e);
        }
    }
}

#[tokio::main]
async fn main() {
    find_source("https://cdn.donmai.us/original/ed/1e/ed1e6e777cf15e42b05f9accf4b28e8c.jpg").await;
}
```

Returns:
`Found results! Output { original_url: "https://cdn.donmai.us/original/ed/1e/ed1e6e777cf15e42b05f9accf4b28e8c.jpg", items: [Item { link: "https://danbooru.donmai.us/posts/9213656", similarity: 0.95 }, Item { link: "https://danbooru.donmai.us/posts/7756900", similarity: 0.61 }, Item { link: "https://danbooru.donmai.us/posts/10077559", similarity: 0.49 }] }
`